### PR TITLE
refactor provider templates

### DIFF
--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsBinderTemplate.cs
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsBinderTemplate.cs
@@ -54,25 +54,19 @@ namespace TypedSignalR.Client.Templates
  } 
             this.Write("\r\n                return compositeDisposable;\r\n            }\r\n        }\r\n\r\n");
  } 
-            this.Write(@"#if NET5_0_OR_GREATER
-        [global::System.Diagnostics.CodeAnalysis.MemberNotNull(""Binders"")]
-#endif
-        private static partial void InitializeBinders()
+            this.Write(@"        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder> CreateBinders()
         {
-            if (Binders is null)
-            {
-                var binders = new global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder>();
+            var binders = new global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder>();
 
 ");
  foreach(var receiverType in ReceiverTypes){ 
-            this.Write("                binders.Add(typeof(");
+            this.Write("            binders.Add(typeof(");
             this.Write(this.ToStringHelper.ToStringWithCulture(receiverType.InterfaceFullName));
             this.Write("), new BinderFor_");
             this.Write(this.ToStringHelper.ToStringWithCulture(receiverType.CollisionFreeName));
             this.Write("());\r\n");
  } 
-            this.Write("\r\n                global::System.Threading.Interlocked.CompareExchange(ref Binder" +
-                    "s, binders, null);\r\n            }\r\n        }\r\n    }\r\n}\r\n");
+            this.Write("\r\n            return binders;\r\n        }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsBinderTemplate.tt
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsBinderTemplate.tt
@@ -28,21 +28,15 @@ namespace TypedSignalR.Client
         }
 
 <# } #>
-#if NET5_0_OR_GREATER
-        [global::System.Diagnostics.CodeAnalysis.MemberNotNull("Binders")]
-#endif
-        private static partial void InitializeBinders()
+        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder> CreateBinders()
         {
-            if (Binders is null)
-            {
-                var binders = new global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder>();
+            var binders = new global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder>();
 
 <# foreach(var receiverType in ReceiverTypes){ #>
-                binders.Add(typeof(<#= receiverType.InterfaceFullName #>), new BinderFor_<#= receiverType.CollisionFreeName #>());
+            binders.Add(typeof(<#= receiverType.InterfaceFullName #>), new BinderFor_<#= receiverType.CollisionFreeName #>());
 <# } #>
 
-                global::System.Threading.Interlocked.CompareExchange(ref Binders, binders, null);
-            }
+            return binders;
         }
     }
 }

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsHubInvokerTemplate.cs
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsHubInvokerTemplate.cs
@@ -72,25 +72,19 @@ namespace TypedSignalR.Client.Templates
             this.Write(this.ToStringHelper.ToStringWithCulture(hubType.CollisionFreeName));
             this.Write("(connection, cancellationToken);\r\n            }\r\n        }\r\n\r\n");
  } 
-            this.Write(@"#if NET5_0_OR_GREATER
-        [global::System.Diagnostics.CodeAnalysis.MemberNotNull(""Factories"")]
-#endif
-        private static partial void InitializeFactories()
+            this.Write(@"        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory> CreateFactories()
         {
-            if (Factories is null)
-            {
-                var factories = new global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory>();
+            var factories = new global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory>();
 
 ");
  foreach(var hubType in HubTypes) {
-            this.Write("                factories.Add(typeof(");
+            this.Write("            factories.Add(typeof(");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubType.InterfaceFullName));
             this.Write("), new HubInvokerFactoryFor_");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubType.CollisionFreeName));
             this.Write("());\r\n");
  } 
-            this.Write("\r\n                global::System.Threading.Interlocked.CompareExchange(ref Factor" +
-                    "ies, factories, null);\r\n            }\r\n        }\r\n    }\r\n}\r\n");
+            this.Write("\r\n            return factories;\r\n        }\r\n    }\r\n}\r\n");
             return this.GenerationEnvironment.ToString();
         }
     }

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsHubInvokerTemplate.tt
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsHubInvokerTemplate.tt
@@ -41,21 +41,15 @@ namespace TypedSignalR.Client
         }
 
 <# } #>
-#if NET5_0_OR_GREATER
-        [global::System.Diagnostics.CodeAnalysis.MemberNotNull("Factories")]
-#endif
-        private static partial void InitializeFactories()
+        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory> CreateFactories()
         {
-            if (Factories is null)
-            {
-                var factories = new global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory>();
+            var factories = new global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory>();
 
 <# foreach(var hubType in HubTypes) {#>
-                factories.Add(typeof(<#= hubType.InterfaceFullName #>), new HubInvokerFactoryFor_<#= hubType.CollisionFreeName #>());
+            factories.Add(typeof(<#= hubType.InterfaceFullName #>), new HubInvokerFactoryFor_<#= hubType.CollisionFreeName #>());
 <# } #>
 
-                global::System.Threading.Interlocked.CompareExchange(ref Factories, factories, null);
-            }
+            return factories;
         }
     }
 }

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.cs
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.cs
@@ -93,84 +93,84 @@ namespace TypedSignalR.Client.Templates
                     "iption, new HubConnectionObserverSubscription(connection, hubConnectionObserver)" +
                     " });\r\n            }\r\n\r\n            return subscription;\r\n        }\r\n    }\r\n\r\n   " +
                     " public static partial class HubConnectionExtensions\r\n    {\r\n        private sta" +
-                    "tic global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvok" +
-                    "erFactory>? Factories = default;\r\n        private static global::System.Collecti" +
-                    "ons.Generic.Dictionary<global::System.Type, IReceiverBinder>? Binders = default;" +
-                    "\r\n\r\n        private static partial void InitializeFactories();\r\n        private " +
-                    "static partial void InitializeBinders();\r\n\r\n        static HubConnectionExtensio" +
-                    "ns()\r\n        {\r\n            InitializeFactories();\r\n            InitializeBinde" +
-                    "rs();\r\n        }\r\n\r\n        private static class HubInvokerFactoryProvider\r\n    " +
-                    "    {\r\n            public static IHubInvokerFactory<T>? GetHubInvokerFactory<T>(" +
-                    ")\r\n            {\r\n                return Cache<T>.HubInvokerFactory;\r\n          " +
-                    "  }\r\n\r\n            private static class Cache<T>\r\n            {\r\n               " +
-                    " public static readonly IHubInvokerFactory<T>? HubInvokerFactory = default;\r\n\r\n " +
-                    "               static Cache()\r\n                {\r\n                    if (Factor" +
-                    "ies is null)\r\n                    {\r\n                        InitializeFactories" +
-                    "();\r\n                    }\r\n\r\n                    if (Factories.TryGetValue(type" +
-                    "of(T), out var hubInvokerFactory))\r\n                    {\r\n                     " +
-                    "   HubInvokerFactory = hubInvokerFactory as IHubInvokerFactory<T>;\r\n            " +
-                    "        }\r\n                }\r\n            }\r\n        }\r\n\r\n        private static" +
-                    " class ReceiverBinderProvider\r\n        {\r\n            public static IReceiverBin" +
-                    "der<T>? GetReceiverBinder<T>()\r\n            {\r\n                return Cache<T>.R" +
-                    "eceiverBinder;\r\n            }\r\n\r\n            private static class Cache<T>\r\n    " +
-                    "        {\r\n                public static readonly IReceiverBinder<T>? ReceiverBi" +
-                    "nder = default;\r\n\r\n                static Cache()\r\n                {\r\n          " +
-                    "          if (Binders is null)\r\n                    {\r\n                        I" +
-                    "nitializeBinders();\r\n                    }\r\n\r\n                    if (Binders.Tr" +
-                    "yGetValue(typeof(T), out var receiverBinder))\r\n                    {\r\n          " +
-                    "              ReceiverBinder = receiverBinder as IReceiverBinder<T>;\r\n          " +
-                    "          }\r\n                }\r\n            }\r\n        }\r\n\r\n        private seal" +
-                    "ed class HubConnectionObserverSubscription : global::System.IDisposable\r\n       " +
-                    " {\r\n            private readonly global::Microsoft.AspNetCore.SignalR.Client.Hub" +
-                    "Connection _connection;\r\n            private readonly IHubConnectionObserver _hu" +
-                    "bConnectionObserver;\r\n\r\n            private int _disposed = 0;\r\n\r\n            pu" +
-                    "blic HubConnectionObserverSubscription(global::Microsoft.AspNetCore.SignalR.Clie" +
-                    "nt.HubConnection connection, IHubConnectionObserver hubConnectionObserver)\r\n    " +
-                    "        {\r\n                _connection = connection;\r\n                _hubConnec" +
-                    "tionObserver = hubConnectionObserver;\r\n\r\n                _connection.Closed += h" +
-                    "ubConnectionObserver.OnClosed;\r\n                _connection.Reconnected += hubCo" +
-                    "nnectionObserver.OnReconnected;\r\n                _connection.Reconnecting += hub" +
-                    "ConnectionObserver.OnReconnecting;\r\n            }\r\n\r\n            public void Dis" +
-                    "pose()\r\n            {\r\n                if (global::System.Threading.Interlocked." +
-                    "Exchange(ref _disposed, 1) == 0)\r\n                {\r\n                    _connec" +
-                    "tion.Closed -= _hubConnectionObserver.OnClosed;\r\n                    _connection" +
-                    ".Reconnected -= _hubConnectionObserver.OnReconnected;\r\n                    _conn" +
-                    "ection.Reconnecting -= _hubConnectionObserver.OnReconnecting;\r\n                }" +
-                    "\r\n            }\r\n        }\r\n\r\n        private sealed class CompositeDisposable :" +
-                    " global::System.IDisposable\r\n        {\r\n            private readonly object _gat" +
-                    "e = new object();\r\n            private readonly global::System.Collections.Gener" +
-                    "ic.List<global::System.IDisposable> _disposables;\r\n\r\n            private bool _d" +
-                    "isposed;\r\n\r\n            public CompositeDisposable()\r\n            {\r\n           " +
-                    "     _disposables = new global::System.Collections.Generic.List<global::System.I" +
-                    "Disposable>();\r\n            }\r\n\r\n            public CompositeDisposable(global::" +
-                    "System.IDisposable[] disposables)\r\n            {\r\n                _disposables =" +
-                    " new global::System.Collections.Generic.List<global::System.IDisposable>(disposa" +
-                    "bles);\r\n            }\r\n\r\n            public CompositeDisposable(int capacity)\r\n " +
-                    "           {\r\n                if (capacity < 0)\r\n                {\r\n            " +
-                    "        throw new global::System.ArgumentOutOfRangeException(nameof(capacity));\r" +
-                    "\n                }\r\n\r\n                _disposables = new global::System.Collecti" +
-                    "ons.Generic.List<global::System.IDisposable>(capacity);\r\n            }\r\n\r\n      " +
-                    "      public void Add(global::System.IDisposable item)\r\n            {\r\n         " +
-                    "       bool shouldDispose = false;\r\n\r\n                lock (_gate)\r\n            " +
-                    "    {\r\n                    shouldDispose = _disposed;\r\n\r\n                    if " +
-                    "(!_disposed)\r\n                    {\r\n                        _disposables.Add(it" +
-                    "em);\r\n                    }\r\n                }\r\n\r\n                if (shouldDisp" +
-                    "ose)\r\n                {\r\n                    item.Dispose();\r\n                }\r" +
-                    "\n            }\r\n\r\n            public void Dispose()\r\n            {\r\n            " +
-                    "    var currentDisposables = default(global::System.Collections.Generic.List<glo" +
-                    "bal::System.IDisposable>);\r\n\r\n                lock (_gate)\r\n                {\r\n " +
-                    "                   if (_disposed)\r\n                    {\r\n                      " +
-                    "  return;\r\n                    }\r\n\r\n                    _disposed = true;\r\n     " +
-                    "               currentDisposables = _disposables;\r\n                }\r\n\r\n        " +
-                    "        foreach (var item in currentDisposables)\r\n                {\r\n           " +
-                    "         if (item is not null)\r\n                    {\r\n                        i" +
-                    "tem.Dispose();\r\n                    }\r\n                }\r\n\r\n                curr" +
-                    "entDisposables.Clear();\r\n            }\r\n        }\r\n\r\n        // It is not possib" +
-                    "le to avoid boxing.\r\n        // This is a limitation caused by the SignalR imple" +
-                    "mentation.\r\n        private static class HandlerConverter\r\n        {\r\n          " +
-                    "  public static global::System.Func<object?[], global::System.Threading.Tasks.Ta" +
-                    "sk> Convert(global::System.Func<global::System.Threading.Tasks.Task> handler)\r\n " +
-                    "           {\r\n                return args => handler();\r\n            }\r\n");
+                    "tic partial global::System.Collections.Generic.Dictionary<global::System.Type, I" +
+                    "HubInvokerFactory> CreateFactories();\r\n        private static partial global::Sy" +
+                    "stem.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder> Create" +
+                    "Binders();\r\n\r\n        private static class HubInvokerFactoryProvider\r\n        {\r" +
+                    "\n            private static global::System.Collections.Generic.Dictionary<global" +
+                    "::System.Type, IHubInvokerFactory> Factories;\r\n\r\n            static HubInvokerFa" +
+                    "ctoryProvider()\r\n            {\r\n                Factories = CreateFactories();\r\n" +
+                    "            }\r\n\r\n            public static IHubInvokerFactory<T>? GetHubInvokerF" +
+                    "actory<T>()\r\n            {\r\n                return Cache<T>.HubInvokerFactory;\r\n" +
+                    "            }\r\n\r\n            private static class Cache<T>\r\n            {\r\n     " +
+                    "           public static readonly IHubInvokerFactory<T>? HubInvokerFactory = def" +
+                    "ault;\r\n\r\n                static Cache()\r\n                {\r\n                    " +
+                    "if (Factories.TryGetValue(typeof(T), out var hubInvokerFactory))\r\n              " +
+                    "      {\r\n                        HubInvokerFactory = hubInvokerFactory as IHubIn" +
+                    "vokerFactory<T>;\r\n                    }\r\n                }\r\n            }\r\n     " +
+                    "   }\r\n\r\n        private static class ReceiverBinderProvider\r\n        {\r\n        " +
+                    "    private static global::System.Collections.Generic.Dictionary<global::System." +
+                    "Type, IReceiverBinder> Binders;\r\n\r\n            static ReceiverBinderProvider()\r\n" +
+                    "            {\r\n                Binders = CreateBinders();\r\n            }\r\n\r\n    " +
+                    "        public static IReceiverBinder<T>? GetReceiverBinder<T>()\r\n            {\r" +
+                    "\n                return Cache<T>.ReceiverBinder;\r\n            }\r\n\r\n            p" +
+                    "rivate static class Cache<T>\r\n            {\r\n                public static reado" +
+                    "nly IReceiverBinder<T>? ReceiverBinder = default;\r\n\r\n                static Cach" +
+                    "e()\r\n                {\r\n                    if (Binders.TryGetValue(typeof(T), o" +
+                    "ut var receiverBinder))\r\n                    {\r\n                        Receiver" +
+                    "Binder = receiverBinder as IReceiverBinder<T>;\r\n                    }\r\n         " +
+                    "       }\r\n            }\r\n        }\r\n\r\n        private sealed class HubConnection" +
+                    "ObserverSubscription : global::System.IDisposable\r\n        {\r\n            privat" +
+                    "e readonly global::Microsoft.AspNetCore.SignalR.Client.HubConnection _connection" +
+                    ";\r\n            private readonly IHubConnectionObserver _hubConnectionObserver;\r\n" +
+                    "\r\n            private int _disposed = 0;\r\n\r\n            public HubConnectionObse" +
+                    "rverSubscription(global::Microsoft.AspNetCore.SignalR.Client.HubConnection conne" +
+                    "ction, IHubConnectionObserver hubConnectionObserver)\r\n            {\r\n           " +
+                    "     _connection = connection;\r\n                _hubConnectionObserver = hubConn" +
+                    "ectionObserver;\r\n\r\n                _connection.Closed += hubConnectionObserver.O" +
+                    "nClosed;\r\n                _connection.Reconnected += hubConnectionObserver.OnRec" +
+                    "onnected;\r\n                _connection.Reconnecting += hubConnectionObserver.OnR" +
+                    "econnecting;\r\n            }\r\n\r\n            public void Dispose()\r\n            {\r" +
+                    "\n                if (global::System.Threading.Interlocked.Exchange(ref _disposed" +
+                    ", 1) == 0)\r\n                {\r\n                    _connection.Closed -= _hubCon" +
+                    "nectionObserver.OnClosed;\r\n                    _connection.Reconnected -= _hubCo" +
+                    "nnectionObserver.OnReconnected;\r\n                    _connection.Reconnecting -=" +
+                    " _hubConnectionObserver.OnReconnecting;\r\n                }\r\n            }\r\n     " +
+                    "   }\r\n\r\n        private sealed class CompositeDisposable : global::System.IDispo" +
+                    "sable\r\n        {\r\n            private readonly object _gate = new object();\r\n   " +
+                    "         private readonly global::System.Collections.Generic.List<global::System" +
+                    ".IDisposable> _disposables;\r\n\r\n            private bool _disposed;\r\n\r\n          " +
+                    "  public CompositeDisposable()\r\n            {\r\n                _disposables = ne" +
+                    "w global::System.Collections.Generic.List<global::System.IDisposable>();\r\n      " +
+                    "      }\r\n\r\n            public CompositeDisposable(global::System.IDisposable[] d" +
+                    "isposables)\r\n            {\r\n                _disposables = new global::System.Co" +
+                    "llections.Generic.List<global::System.IDisposable>(disposables);\r\n            }\r" +
+                    "\n\r\n            public CompositeDisposable(int capacity)\r\n            {\r\n        " +
+                    "        if (capacity < 0)\r\n                {\r\n                    throw new glob" +
+                    "al::System.ArgumentOutOfRangeException(nameof(capacity));\r\n                }\r\n\r\n" +
+                    "                _disposables = new global::System.Collections.Generic.List<globa" +
+                    "l::System.IDisposable>(capacity);\r\n            }\r\n\r\n            public void Add(" +
+                    "global::System.IDisposable item)\r\n            {\r\n                bool shouldDisp" +
+                    "ose = false;\r\n\r\n                lock (_gate)\r\n                {\r\n               " +
+                    "     shouldDispose = _disposed;\r\n\r\n                    if (!_disposed)\r\n        " +
+                    "            {\r\n                        _disposables.Add(item);\r\n                " +
+                    "    }\r\n                }\r\n\r\n                if (shouldDispose)\r\n                " +
+                    "{\r\n                    item.Dispose();\r\n                }\r\n            }\r\n\r\n    " +
+                    "        public void Dispose()\r\n            {\r\n                var currentDisposa" +
+                    "bles = default(global::System.Collections.Generic.List<global::System.IDisposabl" +
+                    "e>);\r\n\r\n                lock (_gate)\r\n                {\r\n                    if " +
+                    "(_disposed)\r\n                    {\r\n                        return;\r\n           " +
+                    "         }\r\n\r\n                    _disposed = true;\r\n                    current" +
+                    "Disposables = _disposables;\r\n                }\r\n\r\n                foreach (var i" +
+                    "tem in currentDisposables)\r\n                {\r\n                    if (item is n" +
+                    "ot null)\r\n                    {\r\n                        item.Dispose();\r\n      " +
+                    "              }\r\n                }\r\n\r\n                currentDisposables.Clear()" +
+                    ";\r\n            }\r\n        }\r\n\r\n        // It is not possible to avoid boxing.\r\n " +
+                    "       // This is a limitation caused by the SignalR implementation.\r\n        pr" +
+                    "ivate static class HandlerConverter\r\n        {\r\n            public static global" +
+                    "::System.Func<object?[], global::System.Threading.Tasks.Task> Convert(global::Sy" +
+                    "stem.Func<global::System.Threading.Tasks.Task> handler)\r\n            {\r\n        " +
+                    "        return args => handler();\r\n            }\r\n");
  for(int i = 1; i <= 16; i++) { 
             this.Write("            \r\n            public static global::System.Func<object?[], global::Sy" +
                     "stem.Threading.Tasks.Task> Convert<");

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.tt
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.tt
@@ -97,20 +97,18 @@ namespace TypedSignalR.Client
 
     public static partial class HubConnectionExtensions
     {
-        private static global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory>? Factories = default;
-        private static global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder>? Binders = default;
-
-        private static partial void InitializeFactories();
-        private static partial void InitializeBinders();
-
-        static HubConnectionExtensions()
-        {
-            InitializeFactories();
-            InitializeBinders();
-        }
+        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory> CreateFactories();
+        private static partial global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder> CreateBinders();
 
         private static class HubInvokerFactoryProvider
         {
+            private static global::System.Collections.Generic.Dictionary<global::System.Type, IHubInvokerFactory> Factories;
+
+            static HubInvokerFactoryProvider()
+            {
+                Factories = CreateFactories();
+            }
+
             public static IHubInvokerFactory<T>? GetHubInvokerFactory<T>()
             {
                 return Cache<T>.HubInvokerFactory;
@@ -122,11 +120,6 @@ namespace TypedSignalR.Client
 
                 static Cache()
                 {
-                    if (Factories is null)
-                    {
-                        InitializeFactories();
-                    }
-
                     if (Factories.TryGetValue(typeof(T), out var hubInvokerFactory))
                     {
                         HubInvokerFactory = hubInvokerFactory as IHubInvokerFactory<T>;
@@ -137,6 +130,13 @@ namespace TypedSignalR.Client
 
         private static class ReceiverBinderProvider
         {
+            private static global::System.Collections.Generic.Dictionary<global::System.Type, IReceiverBinder> Binders;
+
+            static ReceiverBinderProvider()
+            {
+                Binders = CreateBinders();
+            }
+
             public static IReceiverBinder<T>? GetReceiverBinder<T>()
             {
                 return Cache<T>.ReceiverBinder;
@@ -148,11 +148,6 @@ namespace TypedSignalR.Client
 
                 static Cache()
                 {
-                    if (Binders is null)
-                    {
-                        InitializeBinders();
-                    }
-
                     if (Binders.TryGetValue(typeof(T), out var receiverBinder))
                     {
                         ReceiverBinder = receiverBinder as IReceiverBinder<T>;


### PR DESCRIPTION
There was an issue with static constructors not working well in the .NET WebAssembly runtime. This issue is due to incorrect [trimming](https://devblogs.microsoft.com/dotnet/app-trimming-in-net-5/). To address this issue, the generated source code was a bit messy.

By applying this PR, generated source code will be clean. Of course, there will be no issues caused by trimming.