### PR TITLE
support direct static method invocation

### DIFF
--- a/src/TypedSignalR.Client/SourceGenerator.cs
+++ b/src/TypedSignalR.Client/SourceGenerator.cs
@@ -122,7 +122,7 @@ public sealed class SourceGenerator : IIncrementalGenerator
         var location = sourceSymbol.Location;
         var specialSymbols = pair.Item2;
 
-        var extensionMethodSymbol = methodSymbol.ReducedFrom;
+        var extensionMethodSymbol = methodSymbol.ReducedFrom ?? methodSymbol.ConstructedFrom;
 
         if (extensionMethodSymbol is null)
         {
@@ -152,7 +152,7 @@ public sealed class SourceGenerator : IIncrementalGenerator
         var location = sourceSymbol.Location;
         var specialSymbols = pair.Item2;
 
-        var extensionMethodSymbol = methodSymbol.ReducedFrom;
+        var extensionMethodSymbol = methodSymbol.ReducedFrom ?? methodSymbol.ConstructedFrom;
 
         if (extensionMethodSymbol is null)
         {


### PR DESCRIPTION
Until now, only the following syntax was supported.
```cs
var hubProxy = connection.CreateHubProxy<IHub>();
var subscription = connection.Register<IReceiver>(new Receiver());
```

By applying this pull request, the following syntax is also supported.
```cs
var hubProxy = TypedSignalR.Client.HubConnectionExtensions.CreateHubProxy<IHub>(connection);
var subscription = TypedSignalR.Client.HubConnectionExtensions.Register<IReceiver>(connection, new Receiver());
```