### PR TITLE
Added hint about not using 'var' for HubConnection

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: "7.0.x"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ class Receiver2 : IClientContract, IHubConnectionObserver
 It's very easy to use. 
 
 ```cs
+// Do not use 'var' for the HubConnection to allow the source generator to pick up the type
 HubConnection connection = ...;
 
 var hub = connection.CreateHubProxy<IHubContract>();

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.cs
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.cs
@@ -73,7 +73,7 @@ namespace TypedSignalR.Client.Templates
                     " HubInvokerFactoryProvider.GetHubInvokerFactory<THub>();\r\n\r\n            if (fact" +
                     "ory is null)\r\n            {\r\n                throw new global::System.InvalidOpe" +
                     "rationException($\"Failed to create a hub proxy. TypedSignalR.Client did not gene" +
-                    "rate source code to create a hub proxy, which type is {typeof(THub)}.\");\r\n      " +
+                    "rate source code to create a hub proxy, which is of type {typeof(THub)}.\");\r\n      " +
                     "      }\r\n\r\n            return factory.CreateHubInvoker(connection, cancellationT" +
                     "oken);\r\n        }\r\n\r\n        public static global::System.IDisposable Register<T" +
                     "Receiver>(this global::Microsoft.AspNetCore.SignalR.Client.HubConnection connect" +
@@ -85,7 +85,7 @@ namespace TypedSignalR.Client.Templates
                     "          var binder = ReceiverBinderProvider.GetReceiverBinder<TReceiver>();\r\n\r" +
                     "\n            if (binder is null)\r\n            {\r\n                throw new globa" +
                     "l::System.InvalidOperationException($\"Failed to register a receiver. TypedSignal" +
-                    "R.Client did not generate source code to register a receiver, which type is {typ" +
+                    "R.Client did not generate source code to register a receiver, which is of type {typ" +
                     "eof(TReceiver)}.\");\r\n            }\r\n\r\n            var subscription = binder.Bind" +
                     "(connection, receiver);\r\n\r\n            if (receiver is IHubConnectionObserver hu" +
                     "bConnectionObserver)\r\n            {\r\n                subscription = new Composit" +

--- a/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.tt
+++ b/src/TypedSignalR.Client/Templates/HubConnectionExtensionsTemplate.tt
@@ -58,7 +58,7 @@ namespace TypedSignalR.Client
 
             if (factory is null)
             {
-                throw new global::System.InvalidOperationException($"Failed to create a hub proxy. TypedSignalR.Client did not generate source code to create a hub proxy, which type is {typeof(THub)}.");
+                throw new global::System.InvalidOperationException($"Failed to create a hub proxy. TypedSignalR.Client did not generate source code to create a hub proxy, which is of type {typeof(THub)}.");
             }
 
             return factory.CreateHubInvoker(connection, cancellationToken);
@@ -80,7 +80,7 @@ namespace TypedSignalR.Client
 
             if (binder is null)
             {
-                throw new global::System.InvalidOperationException($"Failed to register a receiver. TypedSignalR.Client did not generate source code to register a receiver, which type is {typeof(TReceiver)}.");
+                throw new global::System.InvalidOperationException($"Failed to register a receiver. TypedSignalR.Client did not generate source code to register a receiver, which is of type {typeof(TReceiver)}.");
             }
 
             var subscription = binder.Bind(connection, receiver);


### PR DESCRIPTION
My auto-reformat replaced the explicit `HubConnection` with `var` leaving me puzzled as to why the source generation suddenly stopped working.

I didn't find this hint in the readme (apologies if I overlooked it), so I am including it in this pull request. Additionally, I took the opportunity to slightly rephrase an error message.

I am unsure whether you accept PRs, so please feel free to reject this PR or cherry-pick only the parts you find appropriate.

Great library!