### PR TITLE
Properly casting return task types when calling InvokeCoreAsync

### DIFF
--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -75,13 +75,13 @@ class Program
             .WithUrl("https://~~~")
             .Build();
 
-        connection.CreateHubProxy<IErrorProxy>(); // error
-        connection.CreateHubProxy<IErrorProxy2>(); // error
-        connection.CreateHubProxy<IErrorProxy3>(); // error
-        connection.CreateHubProxy<IErrorProxy4>(); // error
-        connection.CreateHubProxy<IErrorProxy5>(); // error
-        connection.CreateHubProxy<IErrorProxy6>(); // error
-        connection.CreateHubProxy<IErrorProxy7>(); // error
+        // connection.CreateHubProxy<IErrorProxy>(); // error
+        // connection.CreateHubProxy<IErrorProxy2>(); // error
+        // connection.CreateHubProxy<IErrorProxy3>(); // error
+        // connection.CreateHubProxy<IErrorProxy4>(); // error
+        // connection.CreateHubProxy<IErrorProxy5>(); // error
+        // connection.CreateHubProxy<IErrorProxy6>(); // error
+        // connection.CreateHubProxy<IErrorProxy7>(); // error
 
 
         //var id = connection.ConnectionId;

--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -75,13 +75,13 @@ class Program
             .WithUrl("https://~~~")
             .Build();
 
-        // connection.CreateHubProxy<IErrorProxy>(); // error
-        // connection.CreateHubProxy<IErrorProxy2>(); // error
-        // connection.CreateHubProxy<IErrorProxy3>(); // error
-        // connection.CreateHubProxy<IErrorProxy4>(); // error
-        // connection.CreateHubProxy<IErrorProxy5>(); // error
-        // connection.CreateHubProxy<IErrorProxy6>(); // error
-        // connection.CreateHubProxy<IErrorProxy7>(); // error
+        connection.CreateHubProxy<IErrorProxy>(); // error
+        connection.CreateHubProxy<IErrorProxy2>(); // error
+        connection.CreateHubProxy<IErrorProxy3>(); // error
+        connection.CreateHubProxy<IErrorProxy4>(); // error
+        connection.CreateHubProxy<IErrorProxy5>(); // error
+        connection.CreateHubProxy<IErrorProxy6>(); // error
+        connection.CreateHubProxy<IErrorProxy7>(); // error
 
 
         //var id = connection.ConnectionId;

--- a/sandbox/Example/Program.cs
+++ b/sandbox/Example/Program.cs
@@ -114,7 +114,7 @@ class Program
 
         //hub.Hoge();
         //{
-        var hub = connection.CreateHubProxy<IHubContract>();
+        //var hub = connection.CreateHubProxy<IHubContract>();
         //    var subscription = connection.Register<IClientContract>(new Receiver());
 
         //    hub.SomeHubMethod1("user", "message");

--- a/sandbox/SignalR.Client/Program.cs
+++ b/sandbox/SignalR.Client/Program.cs
@@ -184,7 +184,7 @@ class Program
             .Build();
 
 
-        //await Sample1(connection);
+        await Sample1(connection);
         await Sample2(connection);
     }
 }

--- a/sandbox/SignalR.Client/SignalR.Client.csproj
+++ b/sandbox/SignalR.Client/SignalR.Client.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/SignalR.Server/Hubs/ChatHub.cs
+++ b/sandbox/SignalR.Server/Hubs/ChatHub.cs
@@ -8,7 +8,7 @@ namespace SignalR.Server.Hubs;
 
 public class ChatHub : Hub<IClientContract>, IHubContract
 {
-    public async Task<Status> SendMessage(string user, string message)
+    public async Task<Status?> SendMessage(string user, string message)
     {
         var userDefine = new UserDefineClass() { Datetime = DateTime.Now, RandomId = Guid.NewGuid() };
         await Clients.All.ReceiveMessage(user, message, userDefine);

--- a/sandbox/SignalR.Server/SignalR.Server.csproj
+++ b/sandbox/SignalR.Server/SignalR.Server.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/SignalR.Shared/Shared.cs
+++ b/sandbox/SignalR.Shared/Shared.cs
@@ -22,7 +22,7 @@ public interface IClientContract
 
 public interface IHubContract
 {
-    Task<Status> SendMessage(string user, string message);
+    Task<Status?> SendMessage(string user, string message);
     Task SomeHubMethod();
 }
 
@@ -37,4 +37,5 @@ public class ErrorReceiver : IErrorReceiver
     {
         throw new NotImplementedException();
     }
+    
 }

--- a/sandbox/SignalR.Shared/SignalR.Shared.csproj
+++ b/sandbox/SignalR.Shared/SignalR.Shared.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/TypedSignalR.Client/CodeAnalysis/MethodMetadata.cs
+++ b/src/TypedSignalR.Client/CodeAnalysis/MethodMetadata.cs
@@ -25,11 +25,9 @@ public sealed class MethodMetadata
             .Select(x => new ParameterMetadata(x))
             .ToArray();
 
-        ReturnType = methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        ReturnType = methodSymbol.ReturnType.ToDisplayString();
 
-        INamedTypeSymbol? returnTypeSymbol = methodSymbol.ReturnType as INamedTypeSymbol;
-
-        if (returnTypeSymbol is not null)
+        if (methodSymbol.ReturnType is INamedTypeSymbol returnTypeSymbol)
         {
             IsGenericReturnType = returnTypeSymbol.IsGenericType;
 

--- a/src/TypedSignalR.Client/Properties/launchSettings.json
+++ b/src/TypedSignalR.Client/Properties/launchSettings.json
@@ -1,8 +1,9 @@
 {
-  "profiles": {
-    "TypedSignalR.Client": {
-      "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\..\\tests\\TypedSignalR.Client.Tests\\TypedSignalR.Client.Tests.csproj"
+    "$schema": "http://json.schemastore.org/launchsettings.json",
+    "profiles": {
+        "TypedSignalR.Client": {
+            "commandName": "DebugRoslynComponent",
+            "targetProject": "../../tests/TypedSignalR.Client.Tests/TypedSignalR.Client.Tests.csproj"
+        }
     }
-  }
 }

--- a/src/TypedSignalR.Client/Templates/MethodMetadataExtensions.cs
+++ b/src/TypedSignalR.Client/Templates/MethodMetadataExtensions.cs
@@ -259,7 +259,7 @@ public static class MethodMetadataExtensions
         return $$"""
             public {{method.ReturnType}} {{method.MethodName}}({{method.CreateParametersString()}})
             {
-                return global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync{{method.CreateGenericReturnTypeArgumentString()}}(_connection, nameof({{method.MethodName}}), {{method.CreateArgumentsString()}}, _cancellationToken);
+                return (System.Threading.Tasks.Task<SignalR.Shared.Status?>)global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync{{method.CreateGenericReturnTypeArgumentString()}}(_connection, nameof({{method.MethodName}}), {{method.CreateArgumentsString()}}, _cancellationToken);
             }
 """;
     }
@@ -328,14 +328,7 @@ public static class MethodMetadataExtensions
 
         var returnType = methodMetadata.MethodSymbol.ReturnType as INamedTypeSymbol;
 
-        if (returnType is null)
-        {
-            return string.Empty;
-        }
-
-        var typeArgument = returnType.TypeArguments[0] as INamedTypeSymbol;
-
-        if (typeArgument is null)
+        if (returnType?.TypeArguments[0] is not INamedTypeSymbol typeArgument)
         {
             return string.Empty;
         }

--- a/src/TypedSignalR.Client/Templates/MethodMetadataExtensions.cs
+++ b/src/TypedSignalR.Client/Templates/MethodMetadataExtensions.cs
@@ -259,7 +259,7 @@ public static class MethodMetadataExtensions
         return $$"""
             public {{method.ReturnType}} {{method.MethodName}}({{method.CreateParametersString()}})
             {
-                return (System.Threading.Tasks.Task<SignalR.Shared.Status?>)global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync{{method.CreateGenericReturnTypeArgumentString()}}(_connection, nameof({{method.MethodName}}), {{method.CreateArgumentsString()}}, _cancellationToken);
+                return ({{method.ReturnType}})global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync{{method.CreateGenericReturnTypeArgumentString()}}(_connection, nameof({{method.MethodName}}), {{method.CreateArgumentsString()}}, _cancellationToken);
             }
 """;
     }

--- a/tests/TypedSignalR.Client.Tests.Shared/IClientResultsTestHub.cs
+++ b/tests/TypedSignalR.Client.Tests.Shared/IClientResultsTestHub.cs
@@ -8,6 +8,6 @@ public interface IClientResultsTestHub
 public interface IClientResultsTestHubReceiver
 {
     Task<Guid> GetGuidFromClient(); // struct
-    Task<Person> GetPersonFromClient(); // user defined type
+    Task<Person?> GetPersonFromClient(); // user defined type
     Task<int> SumInClient(int left, int right); // calc
 }

--- a/tests/TypedSignalR.Client.Tests/Hubs/ClientResultsTest.cs
+++ b/tests/TypedSignalR.Client.Tests/Hubs/ClientResultsTest.cs
@@ -57,7 +57,7 @@ public class ClientResultsTest : IntegrationTestBase, IAsyncLifetime, IClientRes
         return Task.FromResult(Guid.Parse("ba3088bb-e7ea-4924-b01b-695e879bb166"));
     }
 
-    public Task<Person> GetPersonFromClient()
+    public Task<Person?> GetPersonFromClient()
     {
         return Task.FromResult(new Person(Guid.Parse("c2368532-2f13-4079-9631-a38a048d84e1"), "Nana Daiba", 7));
     }


### PR DESCRIPTION
This Pull requests changes the generated methods that call InvokeCoreAsync to properly cast to the correct return type so we can use nullable return types in the tasks like Task<Class?> without warnings.

Before:
```csharp
public System.Threading.Tasks.Task<SignalR.Shared.Status> SendMessage(string user, string message)
            {
                return global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync(_connection, nameof(SendMessage), new object?[] { user, message }, _cancellationToken);
            }
```

After:
```csharp
public System.Threading.Tasks.Task<SignalR.Shared.Status?> SendMessage(string user, string message)
            {
                return (System.Threading.Tasks.Task<SignalR.Shared.Status?>)global::Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.InvokeCoreAsync(_connection, nameof(SendMessage), new object?[] { user, message }, _cancellationToken);
            }
```

Already tested with the tests provided in the solution seems to work nicely.